### PR TITLE
Normalize resolve decisions and fix spaCy training

### DIFF
--- a/app/routers/process.py
+++ b/app/routers/process.py
@@ -10,6 +10,9 @@ def load_input_files(file_id: str) -> List[str]:
     return files
 @router.post("/{file_id}")
 def process_file(file_id: str, models: str = "AB"):
+    models = (models or "AB").upper()
+    if any(m not in {"A", "B"} for m in models):
+        raise HTTPException(status_code=400, detail="Parâmetro 'models' inválido. Use combinações de 'A' e 'B'.")
     files = load_input_files(file_id); work_dir = storage.file_dir(file_id, "working")
     all_records_A = []; all_records_B = []
     for path in files:

--- a/app/routers/resolve.py
+++ b/app/routers/resolve.py
@@ -1,12 +1,64 @@
 
 import os, re
+from typing import Any, Optional
+
 from fastapi import APIRouter, HTTPException
-from ..services import storage
+
 from ..models.schemas import CandidateRecord, ResolvePayload
+from ..services import storage
 from ..services.storage import read_json, save_json
+
 router = APIRouter(prefix="/resolve", tags=["resolve"])
+
+
 def _key(r: CandidateRecord) -> str:
     return f"{r.DTMNFR}|{r.ORGAO}|{r.NUM_ORDEM}" if r.DTMNFR else f"{r.ORGAO}|{r.NUM_ORDEM}"
+
+
+def _normalize_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "t", "1", "yes", "y", "sim"}:
+            return True
+        if lowered in {"false", "f", "0", "no", "n", "nao", "não", "não"}:
+            return False
+        if not lowered:
+            return False
+    return bool(value)
+
+
+def _coerce_field_value(field: str, value: Any) -> Any:
+    if field == "NUM_ORDEM":
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=400, detail=f"Valor inválido para {field}: {value!r}")
+    if field == "INDEPENDENTE":
+        normalized = _normalize_bool(value)
+        if normalized is None:
+            return None
+        return normalized
+    return "" if value is None else str(value)
+
+
+def _apply_change(rec: CandidateRecord, field: str, value: Any) -> bool:
+    if not hasattr(rec, field):
+        return False
+    coerced = _coerce_field_value(field, value)
+    if coerced is None and field == "NUM_ORDEM":
+        return False
+    setattr(rec, field, coerced)
+    return True
+
+
 @router.post("/{file_id}")
 def resolve_diffs(file_id: str, payload: ResolvePayload):
     work_dir = storage.file_dir(file_id, "working")
@@ -33,18 +85,16 @@ def resolve_diffs(file_id: str, payload: ResolvePayload):
         rk = d.record_key; rec = final_map.get(rk) or final_map.get(re.sub(r"^\|","", rk))
         if rec is None: continue
         for field, value in d.decision.items():
-            if field == "NUM_ORDEM": setattr(rec, field, int(value))
-            elif field == "INDEPENDENTE": setattr(rec, field, bool(value))
-            else: setattr(rec, field, str(value if value is not None else "")); audit.setdefault(rk, {})[field] = "manual"
+            if _apply_change(rec, field, value):
+                audit.setdefault(rk, {})[field] = "manual"
     for rk, fdict in suggestions.items():
         rec = final_map.get(rk) or final_map.get(re.sub(r"^\|","", rk))
         if rec is None: continue
         manual_fields = set(audit.get(rk, {}).keys())
         for field, sugval in fdict.items():
             if field in manual_fields: continue
-            if field == "NUM_ORDEM": setattr(rec, field, int(sugval))
-            elif field == "INDEPENDENTE": setattr(rec, field, bool(sugval))
-            else: setattr(rec, field, str(sugval if sugval is not None else "")); audit.setdefault(rk, {})[field] = "auto_suggestion"
+            if _apply_change(rec, field, sugval):
+                audit.setdefault(rk, {})[field] = "auto_suggestion"
     final_records = [r.model_dump() for r in final_map.values()]
     save_json(os.path.join(work_dir, "final_records.json"), final_records)
     save_json(os.path.join(work_dir, "final_audit.json"), audit)

--- a/app/services/model_b_spacy.py
+++ b/app/services/model_b_spacy.py
@@ -1,8 +1,10 @@
 
 import os, json, random
-from typing import List, Dict, Any
-from spacy.tokens import DocBin
+from typing import List, Dict, Any, Tuple
+
 import spacy
+from spacy.tokens import DocBin
+from spacy.training import Example
 LABELS = ["SIGLA","NOME_LISTA","NUM_ORDEM","NOME_CANDIDATO","PARTIDO_PROPONENTE","SIMBOLO"]
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 MODELS_DIR = os.path.join(BASE_DIR, "models", "model_B_spacy")
@@ -17,17 +19,17 @@ def _load_index():
     with open(INDEX_PATH,"r",encoding="utf-8") as f: return json.load(f)
 def _save_index(idx): 
     with open(INDEX_PATH,"w",encoding="utf-8") as f: json.dump(idx,f,indent=2)
-def make_spacy_docs(nlp, examples: List[Dict[str, Any]]):
+def make_spacy_docs(nlp, examples: List[Dict[str, Any]]) -> Tuple[DocBin, List[Example]]:
     db = DocBin()
+    training_examples: List[Example] = []
     for ex in examples:
         doc = nlp.make_doc(ex["text"])
-        ents = []
-        for sp in ex.get("spans", []):
-            start, end, label = sp["start"], sp["end"], sp["label"]
-            ents.append(doc.char_span(start, end, label=label))
-        doc.ents = [e for e in ents if e is not None]
-        db.add(doc)
-    return db
+        spans = ex.get("spans", [])
+        annotations = {"entities": [(sp["start"], sp["end"], sp["label"]) for sp in spans]}
+        example = Example.from_dict(doc, annotations)
+        db.add(example.reference)
+        training_examples.append(example)
+    return db, training_examples
 def train(run_id: str, train_examples: List[Dict[str,Any]], dev_examples: List[Dict[str,Any]], base_model: str = "pt_core_news_sm"):
     ensure_dirs()
     try:
@@ -36,21 +38,22 @@ def train(run_id: str, train_examples: List[Dict[str,Any]], dev_examples: List[D
         raise RuntimeError(f"spaCy indisponível: {e}")
     ner = nlp.add_pipe("ner")
     for lb in LABELS: ner.add_label(lb)
-    train_db = make_spacy_docs(nlp, train_examples)
-    dev_db = make_spacy_docs(nlp, dev_examples or train_examples[:max(1, int(0.1*len(train_examples)))])
+    train_db, train_example_objs = make_spacy_docs(nlp, train_examples)
+    dev_examples = dev_examples or train_examples[:max(1, int(0.1*len(train_examples)))]
+    dev_db, _ = make_spacy_docs(nlp, dev_examples)
     train_path = os.path.join(MODELS_DIR, run_id, "train.spacy")
     dev_path = os.path.join(MODELS_DIR, run_id, "dev.spacy")
     os.makedirs(os.path.dirname(train_path), exist_ok=True)
     train_db.to_disk(train_path); dev_db.to_disk(dev_path)
     # treino simples
-    optimizer = nlp.begin_training()
-    TRAIN_DOCS = list(train_db.get_docs(nlp.vocab))
+    _ = nlp.begin_training()
+    TRAIN_EXAMPLES = list(train_example_objs)
     DEV_DOCS = list(dev_db.get_docs(nlp.vocab))
     for epoch in range(20):
-        random.shuffle(TRAIN_DOCS)
+        random.shuffle(TRAIN_EXAMPLES)
         losses = {}
-        for doc in TRAIN_DOCS:
-            nlp.update([doc], losses=losses)
+        for example in TRAIN_EXAMPLES:
+            nlp.update([example], losses=losses)
         # avaliação simples
         _ = sum(len(d.ents) for d in DEV_DOCS)
     out_dir = os.path.join(MODELS_DIR, run_id, "model")
@@ -61,13 +64,17 @@ def evaluate(run_id: str, dev_examples: List[Dict[str,Any]]):
     ensure_dirs(); idx = _load_index()
     if run_id not in idx["runs"]: return {"error":"run_id desconhecido"}
     nlp = spacy.load(idx["runs"][run_id]["path"])
-    total = 0; hit = 0
+    total_gold = 0
+    total_pred = 0
+    hit = 0
     for ex in dev_examples:
         doc = nlp(ex["text"]); gold = {(sp["start"], sp["end"], sp["label"]) for sp in ex.get("spans",[])}
         pred = set((ent.start_char, ent.end_char, ent.label_) for ent in doc.ents)
-        total += len(gold); hit += len(gold & pred)
-    prec = hit / (sum(len(sp["spans"]) for sp in dev_examples) or 1)
-    rec = hit / (total or 1)
+        total_gold += len(gold)
+        total_pred += len(pred)
+        hit += len(gold & pred)
+    prec = hit / (total_pred or 1)
+    rec = hit / (total_gold or 1)
     f1 = 2*prec*rec/(prec+rec) if (prec+rec)>0 else 0.0
     return {"precision": round(prec,3), "recall": round(rec,3), "f1": round(f1,3)}
 def promote(run_id: str):


### PR DESCRIPTION
## Summary
- normalise decision handling in the resolve endpoint, including boolean coercion and audit tracking
- validate and normalise the `models` query parameter in `/process`
- update the spaCy training pipeline to use `Example` objects and report precision correctly

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68dbe51c3a5083218fe4ded83d085acd