### PR TITLE
Add review dashboard UI and review persistence

### DIFF
--- a/src/matching/comparator.py
+++ b/src/matching/comparator.py
@@ -396,4 +396,19 @@ class CandidateComparator:
                 )
                 """,
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS review_decisions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    comparison_id INTEGER NOT NULL UNIQUE,
+                    document_id INTEGER,
+                    reviewer TEXT,
+                    selected_source TEXT NOT NULL,
+                    final_value TEXT,
+                    comment TEXT,
+                    decided_at TEXT NOT NULL,
+                    FOREIGN KEY (comparison_id) REFERENCES candidate_comparisons(id)
+                )
+                """,
+            )
             conn.commit()

--- a/src/review/__init__.py
+++ b/src/review/__init__.py
@@ -1,0 +1,16 @@
+"""Review tooling for reconciling operator outputs."""
+
+from .service import ReviewService
+
+try:  # pragma: no cover - optional dependency guard
+    from .ui import build_review_router
+except ModuleNotFoundError as exc:  # pragma: no cover - triggered when FastAPI is absent
+    if exc.name != "fastapi":
+        raise
+
+    def build_review_router(*_args, **_kwargs):  # type: ignore[override]
+        raise RuntimeError(
+            "FastAPI is required to build the review router. Install 'fastapi' to enable the UI components."
+        )
+
+__all__ = ["ReviewService", "build_review_router"]

--- a/src/review/service.py
+++ b/src/review/service.py
@@ -1,0 +1,304 @@
+"""Database helpers for the review dashboard."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_ALLOWED_SOURCES = {"operator_a", "operator_b", "manual", "agreement"}
+
+
+class ReviewService:
+    """High level helper exposing review-friendly database queries."""
+
+    def __init__(self, db_path: Path | str = Path("data/documents.db")) -> None:
+        self.db_path = Path(db_path)
+        if self.db_path.parent:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialise_db()
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def list_documents_with_disputes(self) -> List[Dict[str, Any]]:
+        """Return a summary of documents that still contain disputes."""
+
+        query = (
+            """
+            SELECT
+                c.document_id,
+                COALESCE(d.file_name, 'Unknown document') AS file_name,
+                COALESCE(d.status, 'MISSING') AS document_status,
+                COUNT(*) AS dispute_count,
+                MAX(c.created_at) AS latest_activity
+            FROM candidate_comparisons AS c
+            LEFT JOIN documents AS d ON d.id = c.document_id
+            WHERE c.status = 'dispute'
+            GROUP BY c.document_id, file_name, document_status
+            ORDER BY latest_activity DESC
+            """
+        )
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(query)
+            rows = cursor.fetchall()
+
+        return [
+            {
+                "document_id": row[0],
+                "file_name": row[1],
+                "document_status": row[2],
+                "dispute_count": row[3],
+                "latest_activity": row[4],
+            }
+            for row in rows
+        ]
+
+    def fetch_comparisons(
+        self,
+        document_id: int,
+        *,
+        status: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return comparison rows for a given document.
+
+        Parameters
+        ----------
+        document_id:
+            Identifier of the document whose comparison rows should be
+            retrieved.
+        status:
+            Optional filter to return only rows with a specific status (e.g.
+            ``"dispute"`` or ``"agreement"``).
+        """
+
+        base_query = (
+            """
+            SELECT
+                c.id,
+                c.document_id,
+                c.status,
+                c.nome_a,
+                c.nome_b,
+                c.partido_a,
+                c.partido_b,
+                c.payload,
+                d.selected_source,
+                d.final_value,
+                d.comment,
+                d.reviewer,
+                d.decided_at
+            FROM candidate_comparisons AS c
+            LEFT JOIN review_decisions AS d ON d.comparison_id = c.id
+            WHERE c.document_id = ?
+            """
+        )
+        params: List[Any] = [document_id]
+        if status:
+            base_query += " AND c.status = ?"
+            params.append(status)
+        base_query += " ORDER BY c.num_ordem IS NULL, c.num_ordem, c.id"
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(base_query, params)
+            rows = cursor.fetchall()
+
+        comparisons: List[Dict[str, Any]] = []
+        for row in rows:
+            payload = json.loads(row[7]) if row[7] else {}
+            comparisons.append(
+                {
+                    "comparison_id": row[0],
+                    "document_id": row[1],
+                    "status": row[2],
+                    "nome_a": row[3],
+                    "nome_b": row[4],
+                    "partido_a": row[5],
+                    "partido_b": row[6],
+                    "payload": payload,
+                    "selected_source": row[8],
+                    "final_value": row[9],
+                    "comment": row[10],
+                    "reviewer": row[11],
+                    "decided_at": row[12],
+                }
+            )
+        return comparisons
+
+    # ------------------------------------------------------------------
+    # Mutations
+    # ------------------------------------------------------------------
+    def save_decision(
+        self,
+        *,
+        comparison_id: int,
+        document_id: int,
+        selected_source: str,
+        final_value: Optional[str],
+        comment: Optional[str] = None,
+        reviewer: Optional[str] = None,
+    ) -> None:
+        """Persist a reviewer decision for a specific comparison row."""
+
+        if selected_source not in _ALLOWED_SOURCES:
+            raise ValueError(
+                f"Unsupported source {selected_source!r}. Allowed values: {sorted(_ALLOWED_SOURCES)}"
+            )
+
+        decided_at = datetime.now(timezone.utc).isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO review_decisions (
+                    comparison_id,
+                    document_id,
+                    reviewer,
+                    selected_source,
+                    final_value,
+                    comment,
+                    decided_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(comparison_id) DO UPDATE SET
+                    document_id = excluded.document_id,
+                    reviewer = excluded.reviewer,
+                    selected_source = excluded.selected_source,
+                    final_value = excluded.final_value,
+                    comment = excluded.comment,
+                    decided_at = excluded.decided_at
+                """,
+                (
+                    comparison_id,
+                    document_id,
+                    reviewer,
+                    selected_source,
+                    final_value,
+                    comment,
+                    decided_at,
+                ),
+            )
+            conn.commit()
+
+    def bulk_accept_agreements(
+        self,
+        *,
+        document_id: int,
+    ) -> int:
+        """Automatically accept agreement rows for the provided document.
+
+        Returns
+        -------
+        int
+            Number of comparison rows that were marked as accepted.
+        """
+
+        fetch_query = (
+            """
+            SELECT id, payload
+            FROM candidate_comparisons
+            WHERE document_id = ? AND status = 'agreement'
+              AND id NOT IN (SELECT comparison_id FROM review_decisions)
+            """
+        )
+
+        decisions: List[tuple[int, Optional[str]]] = []
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(fetch_query, (document_id,))
+            for comparison_id, payload in cursor.fetchall():
+                try:
+                    parsed = json.loads(payload or "{}")
+                except json.JSONDecodeError:
+                    parsed = {}
+                candidate_a = (parsed.get("operator_a") or {}).get("nome_candidato")
+                candidate_b = (parsed.get("operator_b") or {}).get("nome_candidato")
+                final_value = candidate_a or candidate_b
+                decisions.append((comparison_id, final_value))
+
+            for comparison_id, final_value in decisions:
+                conn.execute(
+                    """
+                    INSERT INTO review_decisions (
+                        comparison_id,
+                        document_id,
+                        reviewer,
+                        selected_source,
+                        final_value,
+                        comment,
+                        decided_at
+                    ) VALUES (?, ?, NULL, 'agreement', ?, NULL, ?)
+                    ON CONFLICT(comparison_id) DO NOTHING
+                    """,
+                    (
+                        comparison_id,
+                        document_id,
+                        final_value,
+                        datetime.now(timezone.utc).isoformat(),
+                    ),
+                )
+            conn.commit()
+        return len(decisions)
+
+    # ------------------------------------------------------------------
+    # Document helpers
+    # ------------------------------------------------------------------
+    def get_document_snippet(self, document_id: int, *, max_length: int = 600) -> Dict[str, Any]:
+        """Return a small textual snippet for the requested document."""
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute(
+                "SELECT file_name, ocr_text_path FROM documents WHERE id = ?",
+                (document_id,),
+            )
+            row = cursor.fetchone()
+
+        if row is None:
+            return {
+                "document_id": document_id,
+                "file_name": None,
+                "snippet": "Document metadata not found.",
+            }
+
+        file_name, text_path = row
+        snippet = "No OCR text available for this document."
+        if text_path:
+            path = Path(text_path)
+            if not path.is_absolute():
+                path = (self.db_path.parent / path).resolve()
+            if path.exists():
+                try:
+                    text = path.read_text(encoding="utf-8", errors="ignore")
+                except OSError:
+                    text = ""
+                snippet = text.strip()[:max_length] or "OCR text file is empty."
+            else:
+                snippet = f"OCR text not found at {path}."
+
+        return {
+            "document_id": document_id,
+            "file_name": file_name,
+            "snippet": snippet,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _initialise_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS review_decisions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    comparison_id INTEGER NOT NULL UNIQUE,
+                    document_id INTEGER,
+                    reviewer TEXT,
+                    selected_source TEXT NOT NULL,
+                    final_value TEXT,
+                    comment TEXT,
+                    decided_at TEXT NOT NULL,
+                    FOREIGN KEY (comparison_id) REFERENCES candidate_comparisons(id)
+                )
+                """,
+            )
+            conn.commit()

--- a/src/review/ui.py
+++ b/src/review/ui.py
@@ -1,0 +1,329 @@
+"""FastAPI router exposing the review dashboard."""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+from typing import List, Mapping, Sequence
+
+from fastapi import APIRouter, Form, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+
+from .service import ReviewService
+
+__all__ = ["build_review_router"]
+
+
+def build_review_router(db_path: Path | str = Path("data/documents.db")) -> APIRouter:
+    """Return an :class:`APIRouter` serving the review dashboard."""
+
+    service = ReviewService(db_path=db_path)
+    router = APIRouter()
+
+    @router.get("/review", response_class=HTMLResponse)
+    def review_dashboard(document_id: int | None = None, status: str | None = "dispute") -> HTMLResponse:
+        documents = service.list_documents_with_disputes()
+        active_status = status or None
+        active_document_id = document_id
+        if active_document_id is None and documents:
+            active_document_id = documents[0]["document_id"]
+        comparisons: List[Mapping[str, object]] = []
+        if active_document_id is not None:
+            comparisons = service.fetch_comparisons(active_document_id, status=active_status)
+        content = _render_review_page(
+            documents=documents,
+            comparisons=comparisons,
+            active_document_id=active_document_id,
+            active_status=active_status,
+        )
+        return HTMLResponse(content=content)
+
+    @router.post("/review/decision")
+    def record_decision(
+        comparison_id: int = Form(...),
+        document_id: int = Form(...),
+        selected_source: str = Form(...),
+        final_value: str | None = Form(None),
+        comment: str | None = Form(None),
+        reviewer: str | None = Form(None),
+        status: str | None = Form(None),
+    ) -> RedirectResponse:
+        try:
+            service.save_decision(
+                comparison_id=comparison_id,
+                document_id=document_id,
+                selected_source=selected_source,
+                final_value=final_value,
+                comment=comment,
+                reviewer=reviewer,
+            )
+        except ValueError as exc:  # pragma: no cover - handled by FastAPI runtime
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        redirect_url = f"/review?document_id={document_id}"
+        if status:
+            redirect_url += f"&status={status}"
+        return RedirectResponse(url=redirect_url, status_code=303)
+
+    @router.post("/review/bulk_accept")
+    def bulk_accept(
+        document_id: int = Form(...),
+        status: str | None = Form("dispute"),
+    ) -> RedirectResponse:
+        service.bulk_accept_agreements(document_id=document_id)
+        redirect_url = f"/review?document_id={document_id}"
+        if status:
+            redirect_url += f"&status={status}"
+        return RedirectResponse(url=redirect_url, status_code=303)
+
+    @router.get("/review/snippet/{document_id}")
+    def document_snippet(document_id: int) -> JSONResponse:
+        payload = service.get_document_snippet(document_id)
+        return JSONResponse(content=payload)
+
+    return router
+
+
+def _render_review_page(
+    *,
+    documents: Sequence[Mapping[str, object]],
+    comparisons: Sequence[Mapping[str, object]],
+    active_document_id: int | None,
+    active_status: str | None,
+) -> str:
+    doc_options = _build_document_options(documents, active_document_id)
+    status_options = _build_status_options(active_status)
+    rows = _build_comparison_rows(comparisons, active_document_id, active_status)
+
+    return f"""
+    <!DOCTYPE html>
+    <html lang=\"en\">
+      <head>
+        <meta charset=\"utf-8\" />
+        <title>Document Review</title>
+        <style>
+          body {{ font-family: Arial, sans-serif; margin: 2rem; background-color: #f7f7f7; }}
+          h1 {{ margin-bottom: 1rem; }}
+          .panel {{ background: #fff; padding: 1rem 1.5rem; border-radius: 6px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 1.5rem; }}
+          table {{ border-collapse: collapse; width: 100%; }}
+          th, td {{ border: 1px solid #e0e0e0; padding: 0.5rem; vertical-align: top; }}
+          th {{ background: #fafafa; text-align: left; }}
+          tr.status-dispute {{ background: #fff3e0; }}
+          tr.status-agreement {{ background: #e8f5e9; }}
+          tr.status-missing_operator_a, tr.status-missing_operator_b {{ background: #ede7f6; }}
+          .filters form {{ display: flex; flex-wrap: wrap; gap: 1rem; align-items: center; }}
+          .filters label {{ font-weight: bold; }}
+          .decision-form {{ display: flex; flex-direction: column; gap: 0.3rem; }}
+          .decision-form textarea {{ min-height: 3rem; }}
+          .snippet-panel pre {{ background: #212121; color: #fafafa; padding: 1rem; border-radius: 4px; overflow-x: auto; max-height: 18rem; }}
+          .actions {{ display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem; gap: 1rem; }}
+          .actions form {{ margin: 0; }}
+          .document-summary ul {{ margin: 0; padding-left: 1.2rem; }}
+        </style>
+      </head>
+      <body>
+        <div class=\"panel\">
+          <h1>Review disputed records</h1>
+          <div class=\"filters\">
+            <form method=\"get\" action=\"/review\">{doc_options}
+              <label for=\"status\">Row filter</label>
+              <select name=\"status\" id=\"status\">{status_options}</select>
+              <button type=\"submit\">Apply filters</button>
+            </form>
+          </div>
+          <div class=\"actions\">
+            <div>
+              <strong>Documents with disputes:</strong>
+              <span>{len(documents)}</span>
+            </div>
+            { _render_bulk_accept(active_document_id, active_status) }
+          </div>
+          <div class=\"document-summary\">
+            {_render_document_list(documents, active_document_id)}
+          </div>
+        </div>
+        <div class=\"panel\">
+          <h2>Comparison results</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Operator A</th>
+                <th>Operator B</th>
+                <th>Decision</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows}
+            </tbody>
+          </table>
+        </div>
+        <div class=\"panel snippet-panel\">
+          <div style=\"display:flex; align-items:center; gap:1rem;\">
+            <h2 style=\"margin:0;\">Document snippet</h2>
+            <button type=\"button\" onclick=\"loadSnippet({active_document_id or 'null'})\">Load snippet</button>
+          </div>
+          <pre id=\"snippet-content\">Select a document to preview OCR text.</pre>
+        </div>
+        <script>
+          async function loadSnippet(documentId) {{
+            const output = document.getElementById('snippet-content');
+            if (!documentId) {{
+              output.textContent = 'No document selected.';
+              return;
+            }}
+            output.textContent = 'Loading snippet...';
+            try {{
+              const response = await fetch(`/review/snippet/${{documentId}}`);
+              if (!response.ok) {{
+                output.textContent = 'Failed to load snippet.';
+                return;
+              }}
+              const data = await response.json();
+              output.textContent = data.snippet || 'No snippet available.';
+            }} catch (error) {{
+              output.textContent = 'Failed to load snippet.';
+            }}
+          }}
+        </script>
+      </body>
+    </html>
+    """
+
+
+def _build_document_options(documents: Sequence[Mapping[str, object]], active_document_id: int | None) -> str:
+    options = ["<label for=\"document_id\">Document</label>"]
+    select = ["<select name=\"document_id\" id=\"document_id\">"]
+    for entry in documents:
+        doc_id = entry.get("document_id")
+        label = f"{entry.get('file_name')} ({entry.get('dispute_count')} disputes)"
+        selected = " selected" if active_document_id == doc_id else ""
+        value = "" if doc_id is None else str(doc_id)
+        select.append(
+            f"<option value=\"{html.escape(str(value))}\"{selected}>{html.escape(label)}</option>"
+        )
+    if not documents:
+        select.append('<option value="">No disputes found</option>')
+    select.append("</select>")
+    options.extend(select)
+    return "".join(options)
+
+
+def _build_status_options(active_status: str | None) -> str:
+    statuses = [
+        ("", "All rows"),
+        ("dispute", "Disputes only"),
+        ("agreement", "Agreements only"),
+        ("missing_operator_a", "Only missing from Operator B"),
+        ("missing_operator_b", "Only missing from Operator A"),
+    ]
+    rendered = []
+    for value, label in statuses:
+        selected = " selected" if (active_status or "") == value else ""
+        rendered.append(f"<option value=\"{value}\"{selected}>{html.escape(label)}</option>")
+    return "".join(rendered)
+
+
+def _build_comparison_rows(
+    comparisons: Sequence[Mapping[str, object]],
+    active_document_id: int | None,
+    active_status: str | None,
+) -> str:
+    if not comparisons:
+        return '<tr><td colspan="4">No comparison rows found for the selected filters.</td></tr>'
+
+    rows: List[str] = []
+    for entry in comparisons:
+        comparison_id = entry.get("comparison_id")
+        status = str(entry.get("status") or "unknown")
+        nome_a = html.escape(entry.get("nome_a") or "–")
+        nome_b = html.escape(entry.get("nome_b") or "–")
+        partido_a = html.escape(entry.get("partido_a") or "")
+        partido_b = html.escape(entry.get("partido_b") or "")
+        final_value = entry.get("final_value") or entry.get("nome_a") or entry.get("nome_b") or ""
+        selected_source = entry.get("selected_source") or ""
+        comment = entry.get("comment") or ""
+        reviewer = entry.get("reviewer") or ""
+        status_badge = html.escape(status.replace("_", " ").title())
+        rows.append(
+            f"""
+            <tr class=\"status-{status}\">
+              <td>
+                <strong>{comparison_id}</strong><br />
+                <span>{status_badge}</span>
+              </td>
+              <td>
+                <div><strong>{nome_a}</strong></div>
+                <div>{partido_a}</div>
+              </td>
+              <td>
+                <div><strong>{nome_b}</strong></div>
+                <div>{partido_b}</div>
+              </td>
+              <td>
+                <form method=\"post\" action=\"/review/decision\" class=\"decision-form\">
+                  <input type=\"hidden\" name=\"comparison_id\" value=\"{comparison_id}\" />
+                  <input type=\"hidden\" name=\"document_id\" value=\"{active_document_id or ''}\" />
+                  <input type=\"hidden\" name=\"status\" value=\"{active_status or ''}\" />
+                  <label>Preferred source</label>
+                  {_render_source_selector(selected_source)}
+                  <label>Final value</label>
+                  <input type=\"text\" name=\"final_value\" value=\"{html.escape(str(final_value))}\" />
+                  <label>Reviewer</label>
+                  <input type=\"text\" name=\"reviewer\" value=\"{html.escape(str(reviewer))}\" placeholder=\"Your name\" />
+                  <label>Comment</label>
+                  <textarea name=\"comment\" placeholder=\"Notes for this decision\">{html.escape(str(comment))}</textarea>
+                  <button type=\"submit\">Save decision</button>
+                </form>
+              </td>
+            </tr>
+            """
+        )
+    return "".join(rows)
+
+
+def _render_source_selector(selected_source: str | None) -> str:
+    options = [
+        ("operator_a", "Use Operator A"),
+        ("operator_b", "Use Operator B"),
+        ("manual", "Manual override"),
+        ("agreement", "Accepted agreement"),
+    ]
+    rendered = ["<select name=\"selected_source\" required>"]
+    current = selected_source or ""
+    for value, label in options:
+        selected = " selected" if current == value else ""
+        rendered.append(f"<option value=\"{value}\"{selected}>{html.escape(label)}</option>")
+    rendered.append("</select>")
+    return "".join(rendered)
+
+
+def _render_bulk_accept(active_document_id: int | None, active_status: str | None) -> str:
+    if active_document_id is None:
+        return ""
+    status_value = active_status or "dispute"
+    return (
+        "<form method=\"post\" action=\"/review/bulk_accept\">"
+        f"<input type=\"hidden\" name=\"document_id\" value=\"{active_document_id}\" />"
+        f"<input type=\"hidden\" name=\"status\" value=\"{status_value}\" />"
+        "<button type=\"submit\">Accept all agreements</button>"
+        "</form>"
+    )
+
+
+def _render_document_list(
+    documents: Sequence[Mapping[str, object]],
+    active_document_id: int | None,
+) -> str:
+    if not documents:
+        return '<p>No disputes pending review.</p>'
+
+    items: List[str] = []
+    for entry in documents:
+        doc_id = entry.get("document_id")
+        label = f"{entry.get('file_name')} — {entry.get('dispute_count')} disputes"
+        if doc_id == active_document_id:
+            items.append(f"<li><strong>{html.escape(label)}</strong></li>")
+        else:
+            items.append(f"<li>{html.escape(label)}</li>")
+    return "<ul>" + "".join(items) + "</ul>"

--- a/tests/test_review_service.py
+++ b/tests/test_review_service.py
@@ -1,0 +1,134 @@
+import sqlite3
+from pathlib import Path
+
+from matching import CandidateComparator
+from review import ReviewService
+
+
+def _prepare_document_table(db_path: Path, text_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS documents (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_name TEXT NOT NULL,
+                file_hash TEXT NOT NULL UNIQUE,
+                file_size INTEGER NOT NULL,
+                detected_type TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                ocr_pdf_path TEXT,
+                ocr_text_path TEXT,
+                ocr_started_at TEXT,
+                ocr_completed_at TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO documents (
+                id,
+                file_name,
+                file_hash,
+                file_size,
+                detected_type,
+                status,
+                created_at,
+                ocr_text_path
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1,
+                "example.pdf",
+                "hash-1",
+                1024,
+                "PDF_SEARCHABLE",
+                "OCR_DONE",
+                "2024-01-01T00:00:00Z",
+                str(text_path),
+            ),
+        )
+        conn.commit()
+
+
+def _insert_comparisons(db_path: Path) -> None:
+    comparator = CandidateComparator(db_path=db_path)
+    row_agreement = {
+        "document_id": 1,
+        "ORGAO": "Org",
+        "TIPO": 1,
+        "NUM_ORDEM": 1,
+        "NOME_CANDIDATO": "Ana",
+        "PARTIDO_PROPONENTE": "Azul",
+    }
+    row_dispute_a = {
+        "document_id": 1,
+        "ORGAO": "Org",
+        "TIPO": 1,
+        "NUM_ORDEM": 2,
+        "NOME_CANDIDATO": "Bruno",
+        "PARTIDO_PROPONENTE": "Azul",
+    }
+    row_dispute_b = {
+        "document_id": 1,
+        "ORGAO": "Org",
+        "TIPO": 1,
+        "NUM_ORDEM": 2,
+        "NOME_CANDIDATO": "Bruna",
+        "PARTIDO_PROPONENTE": "Azul",
+    }
+    comparator.compare([row_agreement, row_dispute_a], [row_agreement, row_dispute_b])
+
+
+def test_review_service_workflow(tmp_path: Path) -> None:
+    db_path = tmp_path / "review.db"
+    text_path = tmp_path / "snippet.txt"
+    text_path.write_text("Primeira linha\nSegunda linha\nTerceira linha", encoding="utf-8")
+
+    # Prepare schema and baseline comparison records
+    _prepare_document_table(db_path, text_path)
+    ReviewService(db_path=db_path)  # ensure review table exists
+    _insert_comparisons(db_path)
+
+    service = ReviewService(db_path=db_path)
+
+    summary = service.list_documents_with_disputes()
+    assert len(summary) == 1
+    assert summary[0]["document_id"] == 1
+    assert summary[0]["dispute_count"] == 1
+
+    disputes = service.fetch_comparisons(1, status="dispute")
+    assert len(disputes) == 1
+    dispute = disputes[0]
+    assert dispute["status"] == "dispute"
+
+    agreements = service.fetch_comparisons(1, status="agreement")
+    assert len(agreements) == 1
+
+    accepted = service.bulk_accept_agreements(document_id=1)
+    assert accepted == 1
+    # Re-running bulk accept should be idempotent.
+    assert service.bulk_accept_agreements(document_id=1) == 0
+
+    service.save_decision(
+        comparison_id=dispute["comparison_id"],
+        document_id=1,
+        selected_source="operator_a",
+        final_value="Bruno",
+        comment="Prefer operator A",
+        reviewer="Reviewer 1",
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.execute(
+            "SELECT comparison_id, selected_source, final_value, comment, reviewer FROM review_decisions"
+        )
+        saved = cursor.fetchall()
+
+    assert len(saved) == 2
+    # Ensure the manual decision is stored as expected.
+    manual_row = [row for row in saved if row[0] == dispute["comparison_id"]][0]
+    assert manual_row[1:] == ("operator_a", "Bruno", "Prefer operator A", "Reviewer 1")
+
+    snippet = service.get_document_snippet(1)
+    assert "Primeira linha" in snippet["snippet"]


### PR DESCRIPTION
## Summary
- create a review decisions table and helper service to summarise disputes, filter rows, persist reviewer selections, and fetch OCR snippets
- expose a FastAPI router that renders a dispute review dashboard with editable final values, filtering controls, snippet loading, and bulk acceptance actions
- add tests covering the review workflow and database integrations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dceea6e6348321a3a95e71eb8ef7d5