### PR TITLE
Add dashboard frontend and pipeline orchestration API

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,277 @@
+const STAGES = {
+  ingest: {
+    title: "Ingestion",
+    description: "Inspect stored metadata and verify the upload classification.",
+  },
+  ocr: {
+    title: "Optical Character Recognition",
+    description: "Run OCR for scanned PDFs and refresh extracted text artefacts.",
+  },
+  operator_a: {
+    title: "Operator A",
+    description: "Execute text-first parsing heuristics to populate candidate rows.",
+  },
+  operator_b: {
+    title: "Operator B",
+    description: "Execute table-first parsing heuristics to populate candidate rows.",
+  },
+  match: {
+    title: "Match",
+    description: "Regenerate comparison rows to surface agreements and disputes.",
+  },
+  review: {
+    title: "Review",
+    description: "Fetch latest disputes and reviewer decisions for the selected document.",
+  },
+  approve: {
+    title: "Approve",
+    description: "Mark the document as approved once disputes are resolved.",
+  },
+  export: {
+    title: "Export",
+    description: "Produce the CSV export bundle for approved documents.",
+  },
+};
+
+const dashboardBody = document.querySelector("#dashboard-body");
+const stageNav = document.querySelector(".stage-nav");
+const stageContainer = document.querySelector("#stage-container");
+const refreshDashboardButton = document.querySelector("#refresh-dashboard");
+const template = document.querySelector("#stage-template");
+
+let dashboardState = [];
+let activeStage = "ingest";
+
+async function fetchJSON(url, options) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(text || response.statusText);
+  }
+  try {
+    return JSON.parse(text || "{}");
+  } catch (error) {
+    return {};
+  }
+}
+
+async function loadDashboard() {
+  dashboardBody.innerHTML = `<tr><td colspan="5" class="placeholder">Loading…</td></tr>`;
+  try {
+    const data = await fetchJSON("/api/documents/progress");
+    dashboardState = Array.isArray(data) ? data : [];
+    renderDashboard();
+    renderStage(activeStage);
+  } catch (error) {
+    dashboardBody.innerHTML = `<tr><td colspan="5" class="placeholder">${error.message}</td></tr>`;
+  }
+}
+
+function renderDashboard() {
+  if (!dashboardState.length) {
+    dashboardBody.innerHTML = `<tr><td colspan="5" class="placeholder">No documents available.</td></tr>`;
+    return;
+  }
+
+  const rows = dashboardState
+    .map((entry) => {
+      const stageLinks = Object.keys(STAGES)
+        .map(
+          (stage) =>
+            `<a href="#" data-jump="${stage}" data-doc="${entry.id}">${STAGES[stage].title}</a>`
+        )
+        .join("");
+
+      const progress = Math.round(entry.completion * 100);
+      const statusBadge = `<span class="badge" data-state="${entry.status_state}">${entry.status}</span>`;
+      const typeBadge = `<span class="badge" data-state="completed">${entry.detected_type}</span>`;
+      return `
+        <tr>
+          <td><strong>${entry.file_name}</strong></td>
+          <td>${statusBadge}</td>
+          <td>${typeBadge}</td>
+          <td>
+            <div class="progress-bar" role="progressbar" aria-valuenow="${progress}" aria-valuemin="0" aria-valuemax="100">
+              <span style="width: ${progress}%"></span>
+            </div>
+            <small class="hint">${progress}% complete</small>
+          </td>
+          <td class="stage-links">${stageLinks}</td>
+        </tr>
+      `;
+    })
+    .join("");
+
+  dashboardBody.innerHTML = rows;
+}
+
+function renderStage(stage) {
+  activeStage = stage;
+  stageNav.querySelectorAll("button").forEach((button) => {
+    button.classList.toggle("active", button.dataset.stage === stage);
+  });
+
+  const config = STAGES[stage];
+  const node = template.content.firstElementChild.cloneNode(true);
+  node.querySelector("[data-title]").textContent = config.title;
+  node.querySelector("[data-description]").textContent = config.description;
+
+  const select = node.querySelector("[data-document]");
+  select.innerHTML = dashboardState
+    .map((entry) => `<option value="${entry.id}">${entry.file_name}</option>`)
+    .join("");
+
+  if (!dashboardState.length) {
+    select.innerHTML = `<option disabled selected>No documents</option>`;
+  }
+
+  const extra = node.querySelector("[data-extra]");
+  if (stage === "approve") {
+    extra.innerHTML = `
+      <label>
+        <span>Approver ID</span>
+        <input name="approver_id" type="text" placeholder="user@example" required />
+      </label>
+      <label>
+        <span>Approval summary (optional)</span>
+        <textarea name="summary" rows="2" placeholder="Summary for the audit log"></textarea>
+      </label>
+    `;
+  } else if (stage === "review") {
+    extra.innerHTML = `
+      <label>
+        <span>Dispute filter</span>
+        <select name="status">
+          <option value="">All</option>
+          <option value="dispute">Disputes</option>
+          <option value="agreement">Agreements</option>
+        </select>
+      </label>
+    `;
+  } else if (stage === "export") {
+    extra.innerHTML = `
+      <label>
+        <span>Output directory (optional)</span>
+        <input name="output_dir" type="text" placeholder="data/exports" />
+      </label>
+    `;
+  } else {
+    extra.innerHTML = "";
+  }
+
+  const form = node.querySelector("[data-form]");
+  const output = node.querySelector("[data-output]");
+  const statusContainer = node.querySelector("[data-status]");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const formData = new FormData(form);
+    const documentId = formData.get("document") || select.value;
+    if (!documentId) {
+      output.textContent = "Select a document first.";
+      return;
+    }
+    output.textContent = "Running…";
+    const payload = Object.fromEntries(formData.entries());
+    delete payload.document;
+    try {
+      const response = await fetchJSON(`/api/documents/${documentId}/stages/${stage}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      output.textContent = response.message || "Stage completed.";
+      await loadDashboard();
+      renderStage(stage);
+      showStageDetails(statusContainer, response.details);
+    } catch (error) {
+      output.textContent = error.message;
+    }
+  });
+
+  const refreshButton = node.querySelector("[data-refresh]");
+  refreshButton.addEventListener("click", () => {
+    const documentId = select.value;
+    showStageDetails(statusContainer, lookupDocumentStage(documentId, stage));
+  });
+
+  select.addEventListener("change", () => {
+    showStageDetails(statusContainer, lookupDocumentStage(select.value, stage));
+  });
+
+  const initialDoc = select.value;
+  showStageDetails(statusContainer, lookupDocumentStage(initialDoc, stage));
+
+  stageContainer.replaceChildren(node);
+}
+
+function lookupDocumentStage(documentId, stage) {
+  if (!documentId) return null;
+  const entry = dashboardState.find((item) => String(item.id) === String(documentId));
+  if (!entry) return null;
+  return entry.stages ? entry.stages[stage] : null;
+}
+
+function showStageDetails(container, details) {
+  if (!details) {
+    container.innerHTML = `<p class="hint">No data available for this stage.</p>`;
+    return;
+  }
+  const cards = [];
+  if (Array.isArray(details.metrics)) {
+    details.metrics.forEach((metric) => {
+      cards.push(`
+        <article class="stage-card">
+          <header>
+            <strong>${metric.label}</strong>
+            <span class="badge" data-state="${metric.state || "pending"}">${metric.value}</span>
+          </header>
+          ${metric.description ? `<p class="hint">${metric.description}</p>` : ""}
+        </article>
+      `);
+    });
+  }
+  if (details.updated_at) {
+    cards.push(`
+      <article class="stage-card">
+        <header>
+          <strong>Last updated</strong>
+          <span>${new Date(details.updated_at).toLocaleString()}</span>
+        </header>
+      </article>
+    `);
+  }
+  container.innerHTML = cards.join("") || `<p class="hint">Stage metadata pending.</p>`;
+}
+
+stageNav.addEventListener("click", (event) => {
+  const button = event.target.closest("button[data-stage]");
+  if (!button) return;
+  renderStage(button.dataset.stage);
+});
+
+dashboardBody.addEventListener("click", (event) => {
+  const link = event.target.closest("a[data-jump]");
+  if (!link) return;
+  event.preventDefault();
+  const stage = link.dataset.jump;
+  renderStage(stage);
+  const select = stageContainer.querySelector("select[data-document]");
+  if (select && link.dataset.doc) {
+    select.value = link.dataset.doc;
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+  stageContainer.scrollIntoView({ behavior: "smooth" });
+});
+
+refreshDashboardButton.addEventListener("click", () => loadDashboard());
+
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/app/sw.js").catch(() => {
+      // ignore registration failures in offline/unsupported environments
+    });
+  });
+}
+
+loadDashboard();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="manifest" href="manifest.json" />
+    <link rel="stylesheet" href="styles.css" />
+    <title>CNE Processing Console</title>
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>CNE Processing Console</h1>
+      <button id="refresh-dashboard" type="button" class="refresh-button">Refresh Dashboard</button>
+    </header>
+
+    <main>
+      <section id="dashboard" class="panel">
+        <header class="panel-header">
+          <h2>Document Pipeline Overview</h2>
+          <p class="hint">
+            Track per-stage progress and jump directly into the workflow.
+          </p>
+        </header>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Document</th>
+                <th>Status</th>
+                <th>Type</th>
+                <th>Progress</th>
+                <th>Stages</th>
+              </tr>
+            </thead>
+            <tbody id="dashboard-body">
+              <tr>
+                <td colspan="5" class="placeholder">No documents loaded yet.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <nav class="stage-nav" aria-label="Processing stages">
+        <button data-stage="ingest" class="active">Ingest</button>
+        <button data-stage="ocr">OCR</button>
+        <button data-stage="operator_a">Operator A</button>
+        <button data-stage="operator_b">Operator B</button>
+        <button data-stage="match">Match</button>
+        <button data-stage="review">Review</button>
+        <button data-stage="approve">Approve</button>
+        <button data-stage="export">Export</button>
+      </nav>
+
+      <section id="stage-container"></section>
+    </main>
+
+    <template id="stage-template">
+      <section class="panel stage-panel">
+        <header class="panel-header">
+          <h2 data-title></h2>
+          <p class="hint" data-description></p>
+        </header>
+        <form data-form class="stage-form">
+          <label>
+            <span>Select document</span>
+            <select name="document" data-document></select>
+          </label>
+          <div data-extra></div>
+          <div class="actions">
+            <button type="submit" class="primary">Run stage</button>
+            <button type="button" data-refresh>Reload status</button>
+          </div>
+        </form>
+        <output data-output></output>
+        <section class="stage-status" data-status></section>
+      </section>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/frontend/manifest.json
+++ b/frontend/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "CNE Processing Console",
+  "short_name": "CNE Console",
+  "start_url": "/app/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#265acc",
+  "icons": []
+}

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,310 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --surface: #ffffffd8;
+  --border: #d0d7de;
+  --accent: #265acc;
+  --accent-contrast: #ffffff;
+  --text-muted: #6c757d;
+  --bg: #f5f7fb;
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: rgba(15, 23, 42, 0.9);
+    --border: rgba(148, 163, 184, 0.25);
+    --accent: #8bafff;
+    --accent-contrast: #0f172a;
+    --text-muted: #9ca3af;
+    --bg: #0f172a;
+    --shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0 1.5rem 3rem;
+  background: radial-gradient(circle at top left, rgba(38, 90, 204, 0.15), transparent 45%), var(--bg);
+  min-height: 100vh;
+  color: #111827;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #f8fafc;
+  }
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0 1rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 2vw + 1rem, 2.6rem);
+  letter-spacing: -0.02em;
+}
+
+.refresh-button {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--shadow);
+}
+
+.refresh-button:hover,
+.stage-nav button:hover,
+.actions .primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(38, 90, 204, 0.2);
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+}
+
+.hint {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: rgba(38, 90, 204, 0.08);
+}
+
+td,
+th {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  background: rgba(38, 90, 204, 0.12);
+  color: #1e3a8a;
+}
+
+.badge[data-state="completed"] {
+  background: rgba(16, 185, 129, 0.2);
+  color: #047857;
+}
+
+.badge[data-state="pending"] {
+  background: rgba(234, 179, 8, 0.18);
+  color: #92400e;
+}
+
+.badge[data-state="in_progress"] {
+  background: rgba(59, 130, 246, 0.2);
+  color: #1d4ed8;
+}
+
+.badge[data-state="ready"] {
+  background: rgba(120, 113, 198, 0.2);
+  color: #5b21b6;
+}
+
+.progress-bar {
+  position: relative;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  overflow: hidden;
+}
+
+.progress-bar span {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, var(--accent), #60a5fa);
+  transition: width 0.4s ease;
+}
+
+.stage-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.stage-links a {
+  text-decoration: none;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(38, 90, 204, 0.1);
+  color: var(--accent);
+}
+
+.stage-nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.stage-nav button {
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: var(--surface);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease;
+}
+
+.stage-nav button.active {
+  background: linear-gradient(90deg, var(--accent), #60a5fa);
+  color: var(--accent-contrast);
+}
+
+.stage-panel {
+  animation: fadeIn 0.25s ease;
+}
+
+.stage-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.stage-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: min(240px, 100%);
+}
+
+.stage-form select,
+.stage-form input,
+.stage-form textarea {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.actions .primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+  border: none;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.actions button[data-refresh] {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.75rem 1.25rem;
+  background: transparent;
+  cursor: pointer;
+}
+
+output {
+  display: block;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.stage-status {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stage-status .stage-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.stage-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.4rem;
+}
+
+.placeholder {
+  text-align: center;
+  padding: 2rem 0;
+  color: var(--text-muted);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 0 1rem 2rem;
+  }
+
+  .stage-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .actions {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -1,0 +1,38 @@
+const CACHE_NAME = "cne-console-v1";
+const OFFLINE_URLS = [
+  "/app/",
+  "/app/index.html",
+  "/app/styles.css",
+  "/app/app.js",
+  "/app/manifest.json",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_URLS))
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (request.method !== "GET") {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(request).catch(() => caches.match("/app/index.html"));
+    })
+  );
+});

--- a/src/dashboard/__init__.py
+++ b/src/dashboard/__init__.py
@@ -1,0 +1,6 @@
+"""Web dashboard application for orchestrating the processing pipeline."""
+
+from .app import PipelineOrchestrator, create_app
+from .progress import fetch_document_progress
+
+__all__ = ["create_app", "fetch_document_progress", "PipelineOrchestrator"]

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,0 +1,261 @@
+"""FastAPI application powering the processing dashboard."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import Body, FastAPI, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from exporter import CsvExporter
+from ingestion.service import IngestionService
+from matching.comparator import CandidateComparator
+from ocr.pipeline import OcrPipeline
+from operators.operator_a import OperatorA
+from operators.operator_b import OperatorB
+from review.service import ReviewService
+
+from .progress import fetch_document_progress
+
+FRONTEND_PREFIX = "/app"
+
+
+class StagePayload(BaseModel):
+    approver_id: str | None = None
+    summary: str | None = None
+    status: str | None = None
+    output_dir: str | None = None
+
+
+class PipelineOrchestrator:
+    """Wrapper responsible for executing individual processing stages."""
+
+    def __init__(self, db_path: Path | str = Path("data/documents.db")) -> None:
+        self.db_path = Path(db_path)
+        self.ingestion = IngestionService(db_path=self.db_path)
+        self.ocr = OcrPipeline(db_path=self.db_path)
+        self.operator_a = OperatorA(db_path=self.db_path)
+        self.operator_b = OperatorB(db_path=self.db_path)
+        self.comparator = CandidateComparator(db_path=self.db_path)
+        self.review = ReviewService(db_path=self.db_path)
+
+    # ------------------------------------------------------------------
+    # Stage runners
+    # ------------------------------------------------------------------
+    def run_stage(self, stage: str, document_id: int, payload: StagePayload) -> Dict[str, Any]:
+        stage = stage.lower()
+        if stage == "ingest":
+            record = self._get_document(document_id)
+            return {"message": "Ingestion metadata refreshed.", "details": self._document_details(record)}
+        if stage == "ocr":
+            record = self.ocr.run_for_document(document_id)
+            return {"message": "OCR pipeline executed.", "details": self._document_details(record)}
+        if stage == "operator_a":
+            rows = self._run_operator(self.operator_a, document_id)
+            return {"message": f"Operator A stored {len(rows)} rows.", "details": self._simple_metric("Rows", len(rows))}
+        if stage == "operator_b":
+            rows = self._run_operator(self.operator_b, document_id)
+            return {"message": f"Operator B stored {len(rows)} rows.", "details": self._simple_metric("Rows", len(rows))}
+        if stage == "match":
+            comparisons = self._run_comparator(document_id)
+            return {
+                "message": f"{len(comparisons)} comparison rows generated.",
+                "details": self._simple_metric("Comparisons", len(comparisons)),
+            }
+        if stage == "review":
+            status_filter = payload.status or None
+            comparisons = self.review.fetch_comparisons(document_id, status=status_filter)
+            metrics = self._simple_metric(
+                "Rows fetched",
+                len(comparisons),
+                description="Rows available for reviewer inspection.",
+            )
+            return {
+                "message": f"Fetched {len(comparisons)} comparison rows for review.",
+                "details": metrics,
+            }
+        if stage == "approve":
+            approver = (payload.approver_id or "dashboard").strip()
+            if not approver:
+                raise ValueError("An approver identifier is required.")
+            self.review.approve_document(document_id=document_id, approver_id=approver, summary=payload.summary)
+            return {
+                "message": f"Document {document_id} marked as approved.",
+                "details": self._simple_metric("Approver", approver),
+            }
+        if stage == "export":
+            exporter = CsvExporter(db_path=self.db_path, output_dir=payload.output_dir)
+            result = exporter.export()
+            self._record_export_event(document_id)
+            stats = result.stats
+            mtime = datetime.fromtimestamp(result.csv_path.stat().st_mtime, timezone.utc).isoformat()
+            metrics = {
+                "updated_at": mtime,
+                "metrics": [
+                    {
+                        "label": "CSV path",
+                        "value": str(result.csv_path),
+                        "state": "completed",
+                    },
+                    {
+                        "label": "QA report",
+                        "value": str(result.qa_path),
+                        "state": "completed",
+                    },
+                    {
+                        "label": "Rows exported",
+                        "value": stats.get("rows", 0),
+                        "state": "completed" if stats.get("rows") else "pending",
+                    },
+                ],
+            }
+            return {
+                "message": "Export bundle generated successfully.",
+                "details": metrics,
+            }
+        raise ValueError(f"Unsupported stage {stage!r}.")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _run_operator(self, operator: Any, document_id: int) -> list:
+        record = self._get_document(document_id)
+        text_path = record.ocr_text_path
+        if text_path:
+            text_file = Path(text_path)
+            if not text_file.is_absolute():
+                text_file = (self.db_path.parent / text_file).resolve()
+            text = text_file.read_text(encoding="utf-8", errors="ignore")
+        else:
+            upload_path = self.db_path.parent / "uploads" / f"{record.file_hash}.txt"
+            text = ""
+            if upload_path.exists():
+                text = upload_path.read_text(encoding="utf-8", errors="ignore")
+        if not text:
+            raise ValueError("No textual source available for operator execution.")
+        rows = operator.run(
+            document_id=document_id,
+            text=text,
+            dtmnfr=record.file_name,
+            orgao="",
+            sigla="",
+            simbolo="",
+            nome_lista=record.file_name,
+        )
+        return rows
+
+    def _run_comparator(self, document_id: int):
+        operator_a_rows = self._fetch_operator_rows("operator_a_results", document_id)
+        operator_b_rows = self._fetch_operator_rows("operator_b_results", document_id)
+        if not operator_a_rows and not operator_b_rows:
+            raise ValueError("Operators must run before matching.")
+        return self.comparator.compare(operator_a_rows, operator_b_rows)
+
+    def _fetch_operator_rows(self, table: str, document_id: int):
+        query = f"SELECT * FROM {table} WHERE document_id = ? ORDER BY tipo, num_ordem"
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = [dict(row) for row in conn.execute(query, (document_id,))]
+        return rows
+
+    def _get_document(self, document_id: int):
+        record = self.ingestion.get_document(document_id)
+        if record is None:
+            raise ValueError(f"Document {document_id} not found.")
+        return record
+
+    def _document_details(self, record: Any) -> Dict[str, Any]:
+        return {
+            "metrics": [
+                {
+                    "label": "Status",
+                    "value": getattr(record.status, "value", str(record.status)),
+                    "state": "completed",
+                },
+                {
+                    "label": "Detected type",
+                    "value": getattr(record.detected_type, "value", str(record.detected_type)),
+                    "state": "completed",
+                },
+            ],
+            "updated_at": getattr(record, "ocr_completed_at", None) or getattr(record, "created_at", None),
+        }
+
+    def _simple_metric(self, label: str, value: Any, *, description: str | None = None) -> Dict[str, Any]:
+        return {
+            "metrics": [
+                {
+                    "label": label,
+                    "value": value,
+                    "state": "completed" if value else "pending",
+                    "description": description,
+                }
+            ]
+        }
+
+    def _record_export_event(self, document_id: int) -> None:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO audit_log (document_id, actor_id, action, summary, created_at)
+                VALUES (?, ?, 'export_bundle', NULL, ?)
+                """,
+                (document_id, "dashboard", timestamp),
+            )
+            conn.commit()
+
+
+def create_app(db_path: Path | str = Path("data/documents.db")) -> FastAPI:
+    """Return a configured FastAPI application for the dashboard."""
+
+    db_path = Path(db_path)
+    orchestrator = PipelineOrchestrator(db_path=db_path)
+
+    app = FastAPI(title="CNE Processing Console")
+
+    app.include_router(orchestrator.ingestion.build_router())
+
+    @app.get("/api/documents/progress")
+    def documents_progress() -> JSONResponse:
+        return JSONResponse(fetch_document_progress(db_path))
+
+    @app.post("/api/documents/{document_id}/stages/{stage}")
+    def run_stage(
+        document_id: int,
+        stage: str,
+        payload: StagePayload | None = Body(default=None),
+    ) -> JSONResponse:
+        try:
+            result = orchestrator.run_stage(stage, document_id, payload or StagePayload())
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return JSONResponse(result)
+
+    frontend_dir = Path(__file__).resolve().parents[2] / "frontend"
+    if frontend_dir.exists():
+        app.mount(
+            FRONTEND_PREFIX,
+            StaticFiles(directory=frontend_dir, html=True),
+            name="frontend",
+        )
+
+        index_path = frontend_dir / "index.html"
+
+        @app.get("/", response_class=HTMLResponse, include_in_schema=False)
+        def root() -> HTMLResponse:
+            return HTMLResponse(index_path.read_text(encoding="utf-8"))
+
+        @app.get("/sw.js", include_in_schema=False)
+        def service_worker() -> RedirectResponse:
+            return RedirectResponse(url=f"{FRONTEND_PREFIX}/sw.js")
+
+    return app
+
+
+__all__ = ["create_app", "PipelineOrchestrator"]

--- a/src/dashboard/progress.py
+++ b/src/dashboard/progress.py
@@ -1,0 +1,285 @@
+"""Helpers to compute per-document processing progress for the dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import sqlite3
+from typing import Dict, Iterable, List, Mapping
+
+StageName = str
+
+STAGE_ORDER: tuple[StageName, ...] = (
+    "ingest",
+    "ocr",
+    "operator_a",
+    "operator_b",
+    "match",
+    "review",
+    "approve",
+    "export",
+)
+
+
+@dataclass(slots=True)
+class StageMetrics:
+    """Representation of a single stage snapshot."""
+
+    state: str
+    label: str
+    metrics: List[Mapping[str, object]] = field(default_factory=list)
+    updated_at: str | None = None
+
+    def as_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "state": self.state,
+            "label": self.label,
+        }
+        if self.metrics:
+            payload["metrics"] = list(self.metrics)
+        if self.updated_at:
+            payload["updated_at"] = self.updated_at
+        return payload
+
+
+def fetch_document_progress(db_path: str | Path) -> List[Dict[str, object]]:
+    """Return dashboard-friendly progress information for all documents."""
+
+    db_path = Path(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        documents = list(conn.execute("SELECT * FROM documents ORDER BY created_at DESC"))
+
+    progress_rows: List[Dict[str, object]] = []
+    for row in documents:
+        stages = _build_stage_snapshots(db_path, row)
+        completion_ratio = _compute_completion_ratio(stages.values())
+        status_value = str(row["status"]).upper()
+        status_state = "pending"
+        if status_value == "APPROVED":
+            status_state = "completed"
+        elif status_value in {"OCR_DONE", "PROCESSED"}:
+            status_state = "in_progress"
+        elif status_value == "FAILED":
+            status_state = "in_progress"
+
+        progress_rows.append(
+            {
+                "id": row["id"],
+                "file_name": row["file_name"],
+                "detected_type": row["detected_type"],
+                "status": status_value,
+                "status_state": status_state,
+                "completion": completion_ratio,
+                "stages": {name: metrics.as_dict() for name, metrics in stages.items()},
+            }
+        )
+    return progress_rows
+
+
+def _build_stage_snapshots(db_path: Path, document_row: sqlite3.Row) -> Dict[StageName, StageMetrics]:
+    stages: Dict[StageName, StageMetrics] = {}
+    for name in STAGE_ORDER:
+        stages[name] = StageMetrics(state="pending", label=name.replace("_", " ").title())
+
+    stages["ingest"] = StageMetrics(
+        state="completed",
+        label="Ingested",
+        metrics=[
+            {
+                "label": "File size",
+                "value": f"{document_row['file_size']} bytes",
+                "description": f"Uploaded on {document_row['created_at']}",
+                "state": "completed",
+            }
+        ],
+        updated_at=document_row["created_at"],
+    )
+
+    ocr_state, ocr_metrics = _ocr_metrics(document_row)
+    stages["ocr"] = StageMetrics(
+        state=ocr_state,
+        label="OCR",
+        metrics=ocr_metrics,
+        updated_at=document_row["ocr_completed_at"] or document_row["ocr_started_at"],
+    )
+
+    stages["operator_a"] = _operator_metrics(db_path, document_row["id"], "operator_a_results", "Operator A")
+    stages["operator_b"] = _operator_metrics(db_path, document_row["id"], "operator_b_results", "Operator B")
+
+    stages["match"] = _match_metrics(db_path, document_row["id"])
+    stages["review"] = _review_metrics(db_path, document_row["id"])
+    stages["approve"] = _approval_metrics(document_row)
+    stages["export"] = _export_metrics(db_path, document_row["id"], stages["approve"].state)
+
+    return stages
+
+
+def _ocr_metrics(row: sqlite3.Row) -> tuple[str, List[Mapping[str, object]]]:
+    metrics: List[Mapping[str, object]] = []
+    state = "pending"
+    if row["ocr_completed_at"]:
+        state = "completed"
+    elif row["ocr_started_at"]:
+        state = "in_progress"
+    else:
+        state = "pending"
+
+    metrics.append(
+        {
+            "label": "Detected type",
+            "value": row["detected_type"],
+            "state": "completed" if state == "completed" else "pending",
+        }
+    )
+    if row["ocr_text_path"]:
+        metrics.append(
+            {
+                "label": "Transcript",
+                "value": row["ocr_text_path"],
+                "state": "completed" if state == "completed" else state,
+            }
+        )
+    return state, metrics
+
+
+def _operator_metrics(db_path: Path, document_id: int, table: str, label: str) -> StageMetrics:
+    query = f"""
+        SELECT COUNT(*) AS total, MAX(created_at) AS latest
+        FROM {table}
+        WHERE document_id = ?
+    """
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.execute(query, (document_id,))
+        total, latest = cursor.fetchone()
+
+    state = "completed" if total else "pending"
+    metrics = [
+        {
+            "label": "Rows",
+            "value": int(total),
+            "state": state,
+            "description": "Total extracted rows stored for this document.",
+        }
+    ]
+    return StageMetrics(state=state, label=label, metrics=metrics, updated_at=latest)
+
+
+def _match_metrics(db_path: Path, document_id: int) -> StageMetrics:
+    query = """
+        SELECT status, COUNT(*) as total
+        FROM candidate_comparisons
+        WHERE document_id = ?
+        GROUP BY status
+    """
+    totals: Dict[str, int] = {}
+    latest: str | None = None
+    with sqlite3.connect(db_path) as conn:
+        for status, count in conn.execute(query, (document_id,)):
+            totals[str(status)] = int(count)
+        cursor = conn.execute(
+            "SELECT MAX(created_at) FROM candidate_comparisons WHERE document_id = ?",
+            (document_id,),
+        )
+        (latest,) = cursor.fetchone()
+
+    total_rows = sum(totals.values())
+    disputes = totals.get("dispute", 0)
+    state = "completed" if total_rows else "pending"
+    if disputes:
+        state = "in_progress"
+
+    metrics = [
+        {
+            "label": "Total rows",
+            "value": total_rows,
+            "state": "completed" if total_rows else "pending",
+            "description": "Comparison rows available for review.",
+        },
+        {
+            "label": "Disputes",
+            "value": disputes,
+            "state": "in_progress" if disputes else "completed",
+            "description": "Rows requiring manual review.",
+        },
+    ]
+    return StageMetrics(state=state, label="Match", metrics=metrics, updated_at=latest)
+
+
+def _review_metrics(db_path: Path, document_id: int) -> StageMetrics:
+    query = """
+        SELECT COUNT(*) FROM review_decisions WHERE document_id = ?
+    """
+    with sqlite3.connect(db_path) as conn:
+        (total_decisions,) = conn.execute(query, (document_id,)).fetchone()
+        cursor = conn.execute(
+            "SELECT MAX(decided_at) FROM review_decisions WHERE document_id = ?",
+            (document_id,),
+        )
+        (latest,) = cursor.fetchone()
+
+    state = "completed" if total_decisions else "pending"
+    metrics = [
+        {
+            "label": "Decisions",
+            "value": int(total_decisions),
+            "state": state,
+            "description": "Reviewer decisions captured for this document.",
+        }
+    ]
+    return StageMetrics(state=state, label="Review", metrics=metrics, updated_at=latest)
+
+
+def _approval_metrics(row: sqlite3.Row) -> StageMetrics:
+    status = str(row["status"]).upper()
+    state = "completed" if status == "APPROVED" else "pending"
+    metrics = [
+        {
+            "label": "Status",
+            "value": status,
+            "state": state,
+            "description": "Current document lifecycle status.",
+        }
+    ]
+    return StageMetrics(state=state, label="Approve", metrics=metrics)
+
+
+def _export_metrics(db_path: Path, document_id: int, approval_state: str) -> StageMetrics:
+    action_query = """
+        SELECT MAX(created_at) FROM audit_log
+        WHERE document_id = ? AND action LIKE 'export%'
+    """
+    with sqlite3.connect(db_path) as conn:
+        (latest,) = conn.execute(action_query, (document_id,)).fetchone()
+
+    if approval_state != "completed":
+        state = "pending"
+        label = "Export (awaiting approval)"
+    elif latest:
+        state = "completed"
+        label = "Exported"
+    else:
+        state = "ready"
+        label = "Ready to export"
+
+    metrics = [
+        {
+            "label": "Last export",
+            "value": latest or "Not exported",
+            "state": state if latest else "pending",
+            "description": "Timestamp of the most recent export bundle for this document.",
+        }
+    ]
+    return StageMetrics(state=state, label=label, metrics=metrics, updated_at=latest)
+
+
+def _compute_completion_ratio(stages: Iterable[StageMetrics]) -> float:
+    stage_list = list(stages)
+    if not stage_list:
+        return 0.0
+    completed = sum(1 for stage in stage_list if stage.state == "completed")
+    total = len(stage_list)
+    return completed / total if total else 0.0
+
+
+__all__ = ["fetch_document_progress", "STAGE_ORDER"]

--- a/src/ingestion/service.py
+++ b/src/ingestion/service.py
@@ -384,6 +384,33 @@ class IngestionService:
             ocr_completed_at=row["ocr_completed_at"],
         )
 
+    def get_document(self, document_id: int) -> DocumentRecord | None:
+        """Return a document record by its identifier."""
+
+        query = """
+            SELECT
+                id,
+                file_name,
+                file_hash,
+                file_size,
+                detected_type,
+                status,
+                created_at,
+                ocr_pdf_path,
+                ocr_text_path,
+                ocr_started_at,
+                ocr_completed_at
+            FROM documents
+            WHERE id = ?
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(query, (document_id,))
+            row = cursor.fetchone()
+        if row is None:
+            return None
+        return self._row_to_record(row)
+
 
 __all__ = [
     "DocumentRecord",


### PR DESCRIPTION
## Summary
- add an offline-capable frontend with stage navigation for each processing step
- expose FastAPI endpoints to run individual pipeline stages and provide dashboard metrics
- extend ingestion and OCR services with helpers used by the orchestrator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dcfe4af4808321afbe0fda4a029b27