### PR TITLE
Add packaging metadata and document dashboard launch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,33 @@ print(record)
 
 If you are building a FastAPI application, you can expose an ingestion router
 via `service.build_router()`.
+
+## Running the dashboard
+
+The dashboard application lives under the `src/` directory and is distributed as
+an editable Python package. Install it into your environment to make
+`dashboard` importable:
+
+```bash
+pip install -e .
+```
+
+Once installed you can run the ASGI app using Uvicorn:
+
+```bash
+uvicorn dashboard.app:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+If you prefer not to install the package you can instead call the app module
+directly:
+
+```bash
+python -m uvicorn src.dashboard.app:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+For local operators who simply want to launch the service, the repository also
+contains a small helper that adjusts `sys.path` automatically:
+
+```bash
+python scripts/run_dashboard.py
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cne"
+version = "0.1.0"
+description = "CNE dashboard and services"
+readme = "README.md"
+requires-python = ">=3.9"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+dashboard = ["**/*"]

--- a/scripts/run_dashboard.py
+++ b/scripts/run_dashboard.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+"""Launch the dashboard app without requiring installation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import uvicorn
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+    uvicorn.main(
+        [
+            "uvicorn",
+            "src.dashboard.app:create_app",
+            "--factory",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8000",
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a pyproject.toml that configures setuptools to discover the src-based packages
- document editable installs and uvicorn invocation options for the dashboard
- provide a helper script that adjusts sys.path before launching the dashboard server

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dd1656910883219a985ef06804e20b