### PR TITLE
Use uvicorn.run in dashboard runner script

### DIFF
--- a/scripts/run_dashboard.py
+++ b/scripts/run_dashboard.py
@@ -15,16 +15,11 @@ def main() -> None:
     if str(src_path) not in sys.path:
         sys.path.insert(0, str(src_path))
 
-    uvicorn.main(
-        [
-            "uvicorn",
-            "src.dashboard.app:create_app",
-            "--factory",
-            "--host",
-            "0.0.0.0",
-            "--port",
-            "8000",
-        ]
+    uvicorn.run(
+        "src.dashboard.app:create_app",
+        host="0.0.0.0",
+        port=8000,
+        factory=True,
     )
 
 


### PR DESCRIPTION
## Summary
- update the dashboard runner to call `uvicorn.run` with the factory target while preserving the path bootstrapping

## Testing
- `python scripts/run_dashboard.py` *(fails: ModuleNotFoundError: No module named 'uvicorn')*

------
https://chatgpt.com/codex/tasks/task_b_68dd1ccac2848321aa9c0d32cd788c9a