### PR TITLE
Fix dashboard run script import path

### DIFF
--- a/scripts/run_dashboard.py
+++ b/scripts/run_dashboard.py
@@ -16,7 +16,7 @@ def main() -> None:
         sys.path.insert(0, str(src_path))
 
     uvicorn.run(
-        "src.dashboard.app:create_app",
+        "dashboard.app:create_app",
         host="0.0.0.0",
         port=8000,
         factory=True,


### PR DESCRIPTION
## Summary
- update the dashboard helper to load the ASGI app from the importable `dashboard` package while preserving the existing `sys.path` injection

## Testing
- python scripts/run_dashboard.py *(fails: ModuleNotFoundError: No module named 'uvicorn' because the dependency is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dd20320b4c83218245b321cbd52f88