### PR TITLE
Rasterize scanned PDFs before OCR

### DIFF
--- a/tests/test_ocr_pipeline.py
+++ b/tests/test_ocr_pipeline.py
@@ -156,6 +156,48 @@ def _build_searchable_pdf(text: str) -> bytes:
     return buffer.getvalue()
 
 
+def _build_scanned_pdf() -> bytes:
+    """Construct a minimal PDF without a text layer."""
+
+    buffer = io.BytesIO()
+    buffer.write(b"%PDF-1.4\n")
+    buffer.write(b"%\xe2\xe3\xcf\xd3\n")
+
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>",
+    ]
+
+    offsets = [0]
+    for index, obj in enumerate(objects, start=1):
+        offsets.append(buffer.tell())
+        buffer.write(f"{index} 0 obj\n".encode("latin-1"))
+        buffer.write(obj)
+        buffer.write(b"\nendobj\n")
+
+    xref_offset = buffer.tell()
+    total_objects = len(objects)
+    buffer.write(f"xref\n0 {total_objects + 1}\n".encode("latin-1"))
+    buffer.write(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        buffer.write(f"{offset:010d} 00000 n \n".encode("latin-1"))
+    buffer.write(f"trailer\n<< /Root 1 0 R /Size {total_objects + 1} >>\n".encode("latin-1"))
+    buffer.write(f"startxref\n{xref_offset}\n".encode("latin-1"))
+    buffer.write(b"%%EOF\n")
+
+    return buffer.getvalue()
+
+
+_MINIMAL_PNG = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR"
+    b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde"
+    b"\x00\x00\x00\nIDATx\x9cc``\x00\x00\x00\x02\x00\x01\xe2!\xbc3"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
 class DummyOperator:
     def __init__(self) -> None:
         self.calls = []
@@ -205,3 +247,78 @@ def test_pipeline_extracts_text_from_searchable_pdf(tmp_path: Path):
     assert rows == ["ok"]
     assert operator.calls
     assert "Hello searchable PDF" in operator.calls[0]["text"]
+
+
+def test_pipeline_renders_scanned_pdf_to_images(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    uploads_dir = data_dir / "uploads"
+    ocr_dir = data_dir / "ocr"
+    db_path = data_dir / "documents.db"
+
+    ingestion = IngestionService(upload_dir=uploads_dir, db_path=db_path)
+
+    payload = _build_scanned_pdf()
+    record = ingestion.ingest_upload(payload, "scanned.pdf")
+    assert record.detected_type == DocumentType.PDF_SCANNED
+
+    pipeline = OcrPipeline(
+        db_path=db_path,
+        upload_dir=uploads_dir,
+        ocr_output_dir=ocr_dir,
+    )
+
+    render_calls: list[Path] = []
+    tesseract_calls: list[dict[str, object]] = []
+
+    def _fake_render(self, source: Path, destination: Path):
+        page_path = destination / "page-0001.png"
+        page_path.write_bytes(_MINIMAL_PNG)
+        render_calls.append(page_path)
+        return [page_path]
+
+    def _fake_tesseract(self, input_paths, output_base: Path, extra_args=None):
+        if isinstance(input_paths, Path):
+            paths = [input_paths]
+        else:
+            paths = [Path(p) for p in input_paths]
+        tesseract_calls.append(
+            {
+                "inputs": paths,
+                "args": list(extra_args) if extra_args else None,
+            }
+        )
+        if extra_args and "pdf" in extra_args:
+            output_base.with_suffix(".pdf").write_bytes(b"%PDF-1.4\n%%EOF\n")
+        else:
+            output_base.with_suffix(".txt").write_text(
+                "Recognised text from fake OCR",
+                encoding="utf-8",
+            )
+
+    pipeline._render_pdf_to_images = types.MethodType(_fake_render, pipeline)
+    pipeline._run_tesseract = types.MethodType(_fake_tesseract, pipeline)
+
+    updated = pipeline.run_for_document(record.id)
+
+    assert updated.status == DocumentStatus.OCR_DONE
+    assert len(render_calls) == 1
+    assert len(tesseract_calls) == 2
+    assert all(path.suffix == ".png" for call in tesseract_calls for path in call["inputs"])
+    assert tesseract_calls[0]["args"] is None
+    assert tesseract_calls[1]["args"] == ["pdf"]
+
+    text_rel = Path(updated.ocr_text_path)
+    if text_rel.is_absolute():
+        text_file = text_rel
+    else:
+        text_file = (db_path.parent / text_rel).resolve()
+    assert text_file.exists()
+    text_content = text_file.read_text(encoding="utf-8").strip()
+    assert "Recognised text from fake OCR" in text_content
+
+    pdf_rel = Path(updated.ocr_pdf_path)
+    if pdf_rel.is_absolute():
+        pdf_file = pdf_rel
+    else:
+        pdf_file = (db_path.parent / pdf_rel).resolve()
+    assert pdf_file.exists()


### PR DESCRIPTION
## Summary
- rasterize scanned PDFs into temporary images before invoking Tesseract so OCR runs on image inputs
- allow the Tesseract wrapper to accept multiple image paths and rasterize pages via pdf2image
- add regression coverage to simulate scanned PDFs and confirm OCR succeeds without native PDF support

## Testing
- pytest tests/test_ocr_pipeline.py

------
https://chatgpt.com/codex/tasks/task_b_68dd3bbe97608321afaa98957ba7d7bc