### PR TITLE
Add PyMuPDF rasteriser fallback for OCR pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Install the project in editable mode to make the dashboard package available:
 pip install -e .
 ```
 
+The default installation pulls in [PyMuPDF](https://pymupdf.readthedocs.io/),
+providing a pure-Python rasteriser for scanned PDFs. This avoids the external
+Poppler dependency normally required by `pdf2image`, while still allowing that
+backend to be used if both the library and Poppler binaries are installed.
+`OcrPipeline` automatically prefers PyMuPDF and falls back to `pdf2image` when
+available.【F:src/ocr/pipeline.py†L252-L343】
+
 Then start the FastAPI application. The helper script adjusts `sys.path` and
 runs Uvicorn with the correct factory entry point:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ version = "0.1.0"
 description = "CNE dashboard and services"
 readme = "README.md"
 requires-python = ">=3.9"
+dependencies = [
+    "pymupdf>=1.22.5",
+]
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
## Summary
- prefer a PyMuPDF-based renderer for rasterising scanned PDFs and fall back to pdf2image when available
- declare the new PyMuPDF dependency and document the rasteriser requirements
- cover the pdf2image fallback path with a unit test that simulates missing Poppler

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd4e849d0083218ac1a0a9a1402aa7